### PR TITLE
Save mapping w/ the graph edge, not w/ the node

### DIFF
--- a/flowchem/assemblies/LTF_reactors/LTF_reactors.py
+++ b/flowchem/assemblies/LTF_reactors/LTF_reactors.py
@@ -1,24 +1,16 @@
 """ LTF reactors """
 from typing import Optional
-from loguru import logger
 
 from components.stdlib import Channel, YMixer
 from flowchem.components.properties import Component, MappedComponentMixin
 
 
 class LTF_HTM_ST_3_1(MappedComponentMixin, Component):
-    """
-    An LTF HTM ST 3 1 reactor.
-    """
+    """ An LTF HTM ST 3 1 reactor. """
 
     def __init__(self, name: Optional[str] = None):
         super().__init__(name=name)
-        self.mapping = {
-            "INLET_1": None,
-            "INLET_2": None,
-            "QUENCHER": None,
-            "OUTLET": None,
-        }
+        self.mapping = {"INLET_1", "INLET_2", "QUENCHER", "OUTLET"}
 
         inlet1 = Channel(name="INLET_1", length="10 mm", volume="8 ul", material="glass")
         inlet2 = Channel(name="INLET_2", length="10 mm", volume="8 ul", material="glass")
@@ -39,9 +31,3 @@ class LTF_HTM_ST_3_1(MappedComponentMixin, Component):
             (mixer_quencher, reactor2),
             (reactor2, outlet)
         ]
-
-    def _validate(self, dry_run):
-        if any(connection is None for connection in self.mapping.values()):
-            logger.exception(f"{self} requires all connections to be set.")
-            raise ValueError(f"Missing connection in {self}.")
-        return super()._validate(dry_run)

--- a/flowchem/assemblies/__init__.py
+++ b/flowchem/assemblies/__init__.py
@@ -1,1 +1,1 @@
-from .LTF_reactors import *
+from .LTF_reactors import LTF_HTM_ST_3_1

--- a/flowchem/assemblies/assembly.py
+++ b/flowchem/assemblies/assembly.py
@@ -12,7 +12,7 @@ class Assembly(MappedComponentMixin, Component):
     nodes = Sequence[Component]
     edges = Sequence[Tuple[Component, Component]]
 
-    def _subcomponent_by_name(self, name:str) -> Component:
+    def _subcomponent_by_name(self, name: str) -> Component:
         """ Returns a component in self.nodes by its name. """
         for node in self.nodes:
             if node.name == name:
@@ -28,25 +28,27 @@ class Assembly(MappedComponentMixin, Component):
         assert self in graph.graph.nodes, "Assembly must be in the graph to explode it."
 
         # Convert edges to self into edges to self's components.
-        in_edges = list(graph.graph.in_edges(self))
-        out_edges = list(graph.graph.out_edges(self))
-        assert len(in_edges) + len(out_edges) == len(self.mapping), "Assembly has invalid edges."
+        for from_component, to_component, attributes in graph.graph.in_edges(self, data=True):
+            assert to_component is self, "Getting the edges pointing to the assembly."
 
-        for from_component, to_component in in_edges:
-            assert to_component is self, "In edges are edges pointing to the current node!"
-            # Find edge position in assembly mapping
-            position = self.reversed_mapping[from_component]
-            # Add edge to assembly's component
-            self.edges.append((from_component, self._subcomponent_by_name(position)))
+            # New destination is the component with name matching the edge port on the assembly
+            new_to_component = self._subcomponent_by_name(attributes["to_port"])
 
-        for from_component, to_component in out_edges:
-            assert from_component is self, "Out edges are edges pointing from the current node!"
-            # Find edge position in assembly mapping
-            position = self.reversed_mapping[to_component]
-            # Add edge to assembly's component
-            self.edges.append((self._subcomponent_by_name(position), to_component))
+            # Update edge - just add a new one, the old one will be implicitly removed with graph.remove_node(self)
+            graph.add_connection(origin=from_component, destination=new_to_component,
+                                 origin_port=attributes.get("from_port", None))
 
-        # Updates component names. This ensures unique names in the graph.
+        for from_component, to_component, attributes in graph.graph.out_edges(self, data=True):
+            assert from_component is self, "Getting the edges pointing from the assembly."
+
+            # New origin is the component with name matching the edge port on the assembly
+            new_from_component = self._subcomponent_by_name(attributes["from_port"])
+
+            # Update edge - just add a new one, the old one will be implicitly removed with graph.remove_node(self)
+            graph.add_connection(origin=new_from_component, destination=to_component,
+                                 destination_port=attributes.get("to_port", None))
+
+        # Updates component names. Ensures unique names in the graph. (Note: do not update those earlier: see above!)
         for component in self.nodes:
             component.name = f"{self.name}_{component.name}"
 

--- a/flowchem/assemblies/assembly.py
+++ b/flowchem/assemblies/assembly.py
@@ -1,4 +1,4 @@
-from typing import List, Tuple, Sequence
+from typing import Tuple, Sequence
 
 from components.properties import MappedComponentMixin
 from flowchem.core.graph import DeviceGraph

--- a/flowchem/components/dummy/dummy_valve.py
+++ b/flowchem/components/dummy/dummy_valve.py
@@ -22,7 +22,9 @@ class DummyValve(Valve):
     - `setting`: The position of the valve as an int (mapped via `mapping`).
     """
 
-    def __init__(self, name: Optional[str] = None, mapping: dict = {}):
+    def __init__(self, name: Optional[str] = None, mapping: set = None):
+        if mapping is None:
+            mapping = {"position_1", "position_2", "position_3"}
         super().__init__(name=name, mapping=mapping)
 
     async def _update(self) -> None:

--- a/flowchem/components/properties/__init__.py
+++ b/flowchem/components/properties/__init__.py
@@ -1,7 +1,7 @@
 from .base_component import Component
 from .active_component import ActiveComponent
 from .passive_component import PassiveComponent
-from .mapped_component import MappedComponentMixin, ComponentMapping
+from .mapped_component import MappedComponentMixin
 from .sensor import Sensor
 from .valve import Valve
 from .injection_valve import InjectionValve

--- a/flowchem/components/properties/injection_valve.py
+++ b/flowchem/components/properties/injection_valve.py
@@ -1,27 +1,20 @@
+from abc import ABC
 from typing import Optional
 
-from flowchem.components.properties import ComponentMapping, Valve
+from flowchem.components.properties import Valve
 
 
-class InjectionValve(Valve):
+class InjectionValve(Valve, ABC):
     """
     A generic injection valve, i.e. a valve with positions 'inject' and 'load'.
     """
 
     def __init__(
         self,
-        mapping: ComponentMapping = None,
         name: Optional[str] = None,
     ):
         # Ensure that the mapping is a mapping with 'load' and 'ínject' positions
-        if mapping is None:
-            mapping = {
-                "inject": None,
-                "load": None,
-            }
-        else:
-            assert "inject" in mapping
-            assert "load" in mapping
+        mapping = {"inject", "load"}
 
         # Call Valve init
         super().__init__(mapping=mapping, name=name)
@@ -29,6 +22,3 @@ class InjectionValve(Valve):
         # Ensure base state is loading.
         self._base_state = {"setting": "load"}
 
-    async def _update(self):
-        # Left to implementations!
-        raise NotImplementedError

--- a/flowchem/components/properties/mapped_component.py
+++ b/flowchem/components/properties/mapped_component.py
@@ -1,24 +1,7 @@
-import warnings
-from typing import MutableMapping, Union, Optional
+from typing import Set
 
 from flowchem.components.properties import Component
 from loguru import logger
-from collections import UserDict
-
-ComponentMapping = MutableMapping[Union[str, int], Optional[Component]]
-
-
-class distinctdict(UserDict):
-    """Dictionary that does not accept duplicate values except for None.
-    From: Expert Python Programming: Become a master in Python by [...], 3rd Edition"""
-
-    def __setitem__(self, key, value):
-        if value is not None and value in self.values():
-            if key not in self or (key in self and self[key] != value):
-                raise ValueError(
-                    f"Trying to assign the same value to a different key: [{key} => {value}]"
-                )
-        super().__setitem__(key, value)
 
 
 class MappedComponentMixin(Component):
@@ -47,50 +30,14 @@ class MappedComponentMixin(Component):
     - `name`: The name of the component.
 
     """
+    def __init__(self):
+        super().__init__()
+        self.mapping = set()
 
     def _validate(self, dry_run):
-        self.mapping: ComponentMapping
         if not self.mapping:
-            raise ValueError(f"{self} requires a mapping. None provided.")
+            raise ValueError(f"{self} requires a mapping, None provided.")
         assert any(
-            [c is not None for c in self.mapping.values()]
-        ), f"{self} has no mapped components."
+            [c is not None for c in self.mapping]
+        ), f"{self} has no mapped components. Please check the mapping."
         return super()._validate(dry_run)
-
-    @property
-    def reversed_mapping(self):
-        """Return a dictionary of the component's mapping, but with the keys and values swapped."""
-        return {v: k for k, v in self.mapping.items()}
-
-    def solve_mapping_values(self, setting):
-        """Test the values provided for the component mapping and resolve them"""
-        if self.mapping is None:
-            raise ValueError(f"{self} requires a mapping. None provided.")
-
-        # A value is given that is a component to map to
-        if setting in self.reversed_mapping:
-            logger.trace(f"{setting} in {repr(self)}'s mapping.")
-            return self.reversed_mapping[setting]
-
-        # the valve's connecting component name was given
-        # in this case, we get the mapped valve with that name
-        # we don't have to worry about duplicate names since that's checked later
-
-        elif setting in [
-            c.name for c in self.reversed_mapping if isinstance(c, Component)
-        ]:
-            logger.trace(f"{setting} in {repr(self)}'s mapping.")
-            mapped_component = [c for c in self.reversed_mapping if c.name == setting]
-            return self.reversed_mapping[mapped_component[0]]
-
-        # the user gave the actual port mapping number
-        elif setting in self.mapping and isinstance(setting, (int, str)):
-            warnings.warn(
-                "Mapped component should map with other components not directly to position! "
-                "This is deprecated and will remove in future versions.",
-                DeprecationWarning,
-            )
-            logger.trace(f"User supplied manual setting for {self}")
-            return setting
-        else:
-            raise ValueError(f"Invalid setting {setting} for {repr(self)}.")

--- a/flowchem/components/properties/valve.py
+++ b/flowchem/components/properties/valve.py
@@ -1,5 +1,5 @@
 from abc import ABC
-from typing import MutableMapping, Optional, Union, Dict, Any
+from typing import MutableMapping, Optional, Union, Dict, Any, Set
 
 from flowchem.components.properties import (
     ActiveComponent,
@@ -24,20 +24,17 @@ class Valve(MappedComponentMixin, ActiveComponent, ABC):
 
     def __init__(
         self,
-        mapping: MutableMapping[Union[int, str], Optional[Component]],
+        mapping: Set[Union[int, str]],
         name: Optional[str] = None,
     ):
         super().__init__(name=name)
 
-        # check the mapping's type
-        if not isinstance(mapping, (type(None), MutableMapping)):
-            raise TypeError(f"Invalid mapping type {type(mapping)} for {repr(self)}.")
         self.mapping = mapping
         # Base state is first position or 1 if no mapping is provided
         if mapping:
-            self.setting = list(self.mapping.keys())[0]
+            self.setting = next(iter(mapping))
         else:
-            self.setting = 1
+            self.setting = "1"
 
         self._base_state: Dict[str, Any] = {"setting": 1}
 

--- a/flowchem/core/protocol.py
+++ b/flowchem/core/protocol.py
@@ -405,16 +405,10 @@ class Protocol:
                 # show what the valve is actually connecting to
                 if (
                     isinstance(component, MappedComponentMixin)
-                    and type(procedure["setting"]) == int
+                    and "setting" in procedure.keys()
                 ):
-                    assert isinstance(component.mapping, Mapping)
-                    # guess the component, c, which the valve is set to
-                    mapped_component = [
-                        repr(v)
-                        for k, v in component.mapping.items()
-                        if k == procedure["setting"]
-                    ][0]
-                    procedure["mapped component"] = mapped_component
+                    procedure["mapped component"] = self.graph.component_from_origin_and_port(component,
+                                                                                              procedure["setting"])
                 # TODO: make this deterministic for color coordination
                 procedure["params"] = json.dumps(procedure["params"])
 

--- a/tests/test_protocol.py
+++ b/tests/test_protocol.py
@@ -106,8 +106,8 @@ def test_add(device_graph):
 #
 # def test_add_valve():
 #     A = Apparatus()
-#     valve = Valve(mapping={1: pump1, 2: pump2})
-#     bad_valve = Valve(mapping={1: None, 2: None})
+#     valve = Valve(mapping={1, 2})
+#     bad_valve = Valve(mapping={1, 2})
 #     A.add([pump1, pump2], [valve, bad_valve], tube)
 #     P = Protocol(A)
 #


### PR DESCRIPTION
Because it makes more sense, it is already like that in serialization/deserialization.
e.g. current syntax was already

Tube
    from:
        component: foo
        position: bar