### PR TITLE
Adopt unsync for spinsolve

### DIFF
--- a/flowchem/components/devices/Magritek/spinsolve.py
+++ b/flowchem/components/devices/Magritek/spinsolve.py
@@ -1,4 +1,5 @@
 """ Spinsolve module """
+from unsync import unsync
 import asyncio
 import pprint as pp
 import queue
@@ -8,7 +9,7 @@ import warnings
 from flowchem.components.properties import ActiveComponent
 from loguru import logger
 from pathlib import Path
-from typing import Optional, Union
+from typing import Optional, Union, Tuple
 
 from lxml import etree
 from packaging import version
@@ -26,10 +27,18 @@ from flowchem.components.devices.Magritek.parser import (
     StatusNotification,
 )
 from flowchem.components.devices.Magritek.reader import Reader
-from flowchem.components.devices.Magritek.utils import (
-    run_loop,
-    get_streams_for_connection,
-)
+
+
+@unsync
+async def get_streams_for_connection(host: str, port: str) -> Tuple[asyncio.StreamReader, asyncio.StreamWriter]:
+    """
+    Given a target (host, port) returns the corresponding asyncio streams (I/O).
+    """
+    try:
+        read, write = await asyncio.open_connection(host, port)
+    except Exception as e:
+        raise ConnectionError(f"Error connecting to {host}:{port} -- {e}") from e
+    return read, write
 
 
 class Spinsolve(ActiveComponent):
@@ -37,34 +46,25 @@ class Spinsolve(ActiveComponent):
     Spinsolve class, gives access to the spectrometer remote control API
     """
 
-    default_port = 13000
-
     def __init__(
         self,
-        io_reader: asyncio.StreamReader,
-        io_writer: asyncio.StreamWriter,
-        loop,
+        host="127.0.0.1",
         **kwargs,
     ):
         """
         Constructor, actuates the connection upon instantiation.
 
-        Dependency injection is used here with async stream reader/writer.
-        This also simplifies testing.
+        kwargs are: name, xml_schema
         """
 
         super().__init__(kwargs.get("name"))
         # IOs
-        self._io_writer = io_writer
-        self._io_reader = io_reader
+        self._io_reader, self._io_writer = get_streams_for_connection(host, kwargs.get("port", "13000")).result()
+
         # Queue needed for thread-safe operation, the reader is in a different thread
         self._replies: queue.Queue = queue.Queue()
         self._reader = Reader(self._replies, kwargs.get("xml_schema", None))
-
-        # Event loop to run the connection listener
-        self._loop = loop
-        self._loop.create_task(self.connection_listener())
-        threading.Thread(target=lambda: run_loop(self._loop), daemon=True).start()
+        self._reader_thread = threading.Thread(target=lambda: self.connenction_listener_thread(), daemon=True).start()
 
         # Check if the instrument is connected
         hw_info = self.hw_request()
@@ -105,24 +105,11 @@ class Spinsolve(ActiveComponent):
                 f"Spinsolve version {self.software_version} is older than the reference (1.18.1.3062)"
             )
 
-    @classmethod
-    def from_config(cls, **config):
-        """Create instance from config dict"""
-        # Get loop if passed or existing
-        loop = config.get("loop", asyncio.get_event_loop())
-        # Create stream reader/writer pair
-        reader, writer = loop.run_until_complete(
-            get_streams_for_connection(config.get("host"), config.get("port", "13000"))
-        )
-        # Drop keys
-        for key in ("host", "port", "loop"):
-            config.pop(key, None)
-        # Instantiate with the rest of config
-        return cls(reader, writer, loop, **config)
+    def connenction_listener_thread(self):
+        """ Thread that listens to the connection and parses the reply """
+        self.connection_listener().result()
 
-    def __del__(self):
-        self._loop.stop()
-
+    @unsync
     async def connection_listener(self):
         """
         Listen for replies and puts them in the queue
@@ -134,11 +121,13 @@ class Spinsolve(ActiveComponent):
                 break
             self._replies.put(chunk)
 
-    def _transmit(self, message: bytes):
+    @unsync
+    async def _transmit(self, message: bytes):
         """
         Sends the message to the spectrometer
         """
         self._io_writer.write(message)
+        await self._io_writer.drain()
 
     @property
     def solvent(self) -> str:
@@ -230,7 +219,7 @@ class Spinsolve(ActiveComponent):
 
         # Transmit
         logger.debug(f"Transmitting request to spectrometer: {message}")
-        self._transmit(message)
+        self._transmit(message).result()
 
     def hw_request(self):
         """
@@ -401,3 +390,11 @@ class Spinsolve(ActiveComponent):
     def shim(self):
         """Performs a shim on sample"""
         raise NotImplementedError("Use run protocol with a shimming protocol instead!")
+
+
+if __name__ == '__main__':
+    host = "BSMC-YMEF002121"
+
+    nmr: Spinsolve = Spinsolve(host=host)
+    print(nmr.sample)
+

--- a/flowchem/components/devices/Magritek/spinsolve.py
+++ b/flowchem/components/devices/Magritek/spinsolve.py
@@ -116,7 +116,7 @@ class Spinsolve(ActiveComponent):
         """
         while True:
             try:
-                chunk = await self._io_reader.read(1024)
+                chunk = await self._io_reader.readuntil(b"</Message>")
             except asyncio.CancelledError:
                 break
             self._replies.put(chunk)

--- a/flowchem/components/devices/Magritek/utils.py
+++ b/flowchem/components/devices/Magritek/utils.py
@@ -1,5 +1,4 @@
-from typing import Callable, Union, Tuple
-import asyncio
+from typing import Callable, Union
 import ctypes.wintypes
 import warnings
 from pathlib import Path

--- a/flowchem/components/devices/Magritek/utils.py
+++ b/flowchem/components/devices/Magritek/utils.py
@@ -50,26 +50,3 @@ def create_folder_mapper(
             )
 
     return folder_mapper
-
-
-async def get_streams_for_connection(
-    host, port
-) -> Tuple[asyncio.StreamReader, asyncio.StreamWriter]:
-    """
-    Given a target (host, port) returns the corresponding asyncio streams (I/O).
-    """
-    try:
-        read, write = await asyncio.open_connection(host, port)
-    except Exception as e:
-        raise ConnectionError(f"Error connecting to {host}:{port} -- {e}") from e
-    return read, write
-
-
-def run_loop(loop):
-    """
-
-    Args:
-        loop:
-    """
-    asyncio.set_event_loop(loop)
-    loop.run_forever()

--- a/setup.cfg
+++ b/setup.cfg
@@ -43,6 +43,7 @@ install_requires =
     pyserial>=3
     pyyaml>=6.0
     scipy>=1.6.3
+    unsync>=1.0.0
     uvicorn>=0.13.4
     zeroconf>=0.36.2
     google-api-python-client

--- a/setup.cfg
+++ b/setup.cfg
@@ -33,7 +33,7 @@ install_requires =
     lxml>=4.6.4
     matplotlib>=3.5.0
     networkx>=2.6.3
-    nmrglue>=0.8
+    nmrglue @ git+https://github.com/jjhelmus/nmrglue@master#egg=nmrglue
     numpy>=1.20.3
     ord-schema>=0.3.0
     packaging>=21.3
@@ -42,7 +42,7 @@ install_requires =
     pydantic>=1.8.2
     pyserial>=3
     pyyaml>=6.0
-    scipy>=1.6.3, <1.8
+    scipy>=1.6.3
     uvicorn>=0.13.4
     zeroconf>=0.36.2
     google-api-python-client

--- a/tests/test_spinsolve.py
+++ b/tests/test_spinsolve.py
@@ -6,13 +6,14 @@ from pathlib import Path
 from flowchem.components.devices.Magritek.spinsolve import Spinsolve
 
 
-host = "BSMC-7WP43Y1"
+# Change to match your environment ;)
+host = "BSMC-YMEF002121"
 
 
 @pytest.fixture(scope="session")
 def nmr():
-    """ Spinsolve instance on host:port. Change to match your hardware ;) """
-    return Spinsolve.from_config(host=host)
+    """ Needs an actual Spinsolve instance running on the host. """
+    return Spinsolve(host=host)
 
 
 @pytest.mark.Spinsolve


### PR DESCRIPTION
The problem is as follows:

`asyncio` provides a nice high-level API for sockets via `asyncio.open_connection(host, port)` that would be ideal for communication with the Spinsolve NMR.
However, the StreamReader needs to have a dedicated loop continuously reading replies sicne those are not only generated as reply to commands (e.g. when a protocl is running every few seconds a message is sent with update on statues, time left etc).

A loop that runs forever is therefore needed for the StreamReader, but this cannot be the same event loop used in flowchem (assuming the asyncio implementation is selected). Essentially a dedicated thread is needed for IO operations, but this should be transparent to library user. unsync looks like an ok solution as it allows to koeep the nice asyncio-API without forcing the users to adopte async/await, so I'd call it a win-win.

P.S. Further simplifcation of the queue/reader is possible, maybe in followup commit