### PR TITLE
Fix fastapi list kwargs

### DIFF
--- a/src/flowchem/client/component_client.py
+++ b/src/flowchem/client/component_client.py
@@ -27,7 +27,7 @@ class FlowchemComponentClient:
     def put(self, url, data=None, **kwargs):
         """Send a PUT request. Returns :class:`Response` object."""
 
-        # Inspect the keyargs type to avoid ploblems with not str parameters        
+        # Inspect the keyword arguments type to avoid problems with not str parameters        
         for key, arg in kwargs.get("params", {}).items():
             if type(arg) is list:
                 kwargs["params"][key] = str(arg)

--- a/src/flowchem/client/component_client.py
+++ b/src/flowchem/client/component_client.py
@@ -28,9 +28,12 @@ class FlowchemComponentClient:
         """Send a PUT request. Returns :class:`Response` object."""
 
         # Inspect the keyargs type to avoid ploblems with not str parameters
-        if kwargs["params"]:
-            for key, arg in kwargs["params"].items():
-                if type(arg) is list:
-                    kwargs["params"][key] = str(arg)
+        try:
+            if kwargs["params"]:
+                for key, arg in kwargs["params"].items():
+                    if type(arg) is list:
+                        kwargs["params"][key] = str(arg)
+        except:
+            pass
 
         return self._session.put(self.base_url + "/" + url, data=data, **kwargs)

--- a/src/flowchem/client/component_client.py
+++ b/src/flowchem/client/component_client.py
@@ -27,13 +27,9 @@ class FlowchemComponentClient:
     def put(self, url, data=None, **kwargs):
         """Send a PUT request. Returns :class:`Response` object."""
 
-        # Inspect the keyargs type to avoid ploblems with not str parameters
-        try:
-            if kwargs["params"]:
-                for key, arg in kwargs["params"].items():
-                    if type(arg) is list:
-                        kwargs["params"][key] = str(arg)
-        except:
-            pass
-
+        # Inspect the keyargs type to avoid ploblems with not str parameters        
+        for key, arg in kwargs.get("params", {}).items():
+            if type(arg) is list:
+                kwargs["params"][key] = str(arg)
+        
         return self._session.put(self.base_url + "/" + url, data=data, **kwargs)

--- a/src/flowchem/client/component_client.py
+++ b/src/flowchem/client/component_client.py
@@ -27,7 +27,7 @@ class FlowchemComponentClient:
     def put(self, url, data=None, **kwargs):
         """Send a PUT request. Returns :class:`Response` object."""
 
-        # Inspect the keyword arguments type to avoid problems with not str parameters        
+        # Inspect the keyword arguments type to avoid problems with arguments of list type which must be handed to fastapi as str
         for key, arg in kwargs.get("params", {}).items():
             if type(arg) is list:
                 kwargs["params"][key] = str(arg)

--- a/src/flowchem/client/component_client.py
+++ b/src/flowchem/client/component_client.py
@@ -26,4 +26,11 @@ class FlowchemComponentClient:
 
     def put(self, url, data=None, **kwargs):
         """Send a PUT request. Returns :class:`Response` object."""
+
+        # Inspect the keywargs type to avoid ploblems with not str parameters
+        if kwargs["params"]:
+            for key, arg in kwargs["params"].items():
+                if type(arg) is not str:
+                    kwargs["params"][key] = str(arg)
+
         return self._session.put(self.base_url + "/" + url, data=data, **kwargs)

--- a/src/flowchem/client/component_client.py
+++ b/src/flowchem/client/component_client.py
@@ -27,10 +27,10 @@ class FlowchemComponentClient:
     def put(self, url, data=None, **kwargs):
         """Send a PUT request. Returns :class:`Response` object."""
 
-        # Inspect the keywargs type to avoid ploblems with not str parameters
+        # Inspect the keyargs type to avoid ploblems with not str parameters
         if kwargs["params"]:
             for key, arg in kwargs["params"].items():
-                if type(arg) is not str:
+                if type(arg) is list:
                     kwargs["params"][key] = str(arg)
 
         return self._session.put(self.base_url + "/" + url, data=data, **kwargs)

--- a/src/flowchem/components/valves/valve.py
+++ b/src/flowchem/components/valves/valve.py
@@ -210,6 +210,13 @@ class Valve(FlowchemComponent):
             raise DeviceError("Connection is not possible. The valve you selected can not connect selected ports."
                               "This can be due to exclusion of certain connections by setting positions_not_to_connect")
 
+    async def get_position(self) -> list[list[int]]:
+        """
+        Get the current valve position.
+
+        Returns:
+            tuple: The current position of the valve.
+        """
     async def get_position(self) -> tuple[tuple, tuple]:
         """Get current valve position."""
         if not hasattr(self, "identifier"):
@@ -219,8 +226,9 @@ class Valve(FlowchemComponent):
         pos = int(pos) if pos.isnumeric() else pos
         return self._positions[int(self._change_connections(pos, reverse=True))]
 
-
-    async def set_position(self, connect: str | tuple = "", disconnect: str | tuple = "",
+    async def set_position(self,
+                           connect: str = "",
+                           disconnect: str = "",
                            ambiguous_switching: str | bool = False):
         """Move valve to position, which connects named ports"""
         connect=return_tuple_from_input(connect)

--- a/src/flowchem/components/valves/valve.py
+++ b/src/flowchem/components/valves/valve.py
@@ -211,13 +211,6 @@ class Valve(FlowchemComponent):
                               "This can be due to exclusion of certain connections by setting positions_not_to_connect")
 
     async def get_position(self) -> list[list[int]]:
-        """
-        Get the current valve position.
-
-        Returns:
-            tuple: The current position of the valve.
-        """
-    async def get_position(self) -> tuple[tuple, tuple]:
         """Get current valve position."""
         if not hasattr(self, "identifier"):
             pos = await self.hw_device.get_raw_position()


### PR DESCRIPTION
FastAPI does not support nested lists in query parameters. 

The problem stems from how lists are passed through URL query strings in FastAPI. 

To resolve this, we can inspect the kwargs before building the put request inside the ComponentClient to ensure the acceptable type.

For example, consider the following method:

async def set_position(self, connect, ...)

If we try to send an argument like connect = [1, 0] using the URL:

http://127.0.0.1:8000/items/?connect=1&connect=0

What actually gets passed into the method is connect = 0. (This behavior was tested.) FastAPI does not parse the list correctly in this case.

Additionally, if we declare the argument type as:

... connect: list[int] or connect: list[list[int]] ...

The argument does not even appear available in the API documentation, and in some cases, it causes the API initialization to break entirely.

Similar issues have been discussed in forums

https://stackoverflow.com/questions/74759875/how-to-send-a-list-of-lists-as-query-parameter-in-fastapi
