### PR TITLE
docstring access and gitignore update

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -7,9 +7,10 @@
 # -- Path setup --------------------------------------------------------------
 
 # Build the files to DocString reference
-# sphinx-apidoc -o code_structure ../src
+# sphinx-apidoc -o docs/development/foundations/code_structure src
 # Build html
-# sphinx-build -b html -v docs _build/html
+# sphinx-build -b html -v docs docs/_build/html
+# start docs/_build/html/index.html
 
 
 import datetime

--- a/docs/development/foundations/code_structure/flowchem.rst
+++ b/docs/development/foundations/code_structure/flowchem.rst
@@ -1,0 +1,23 @@
+flowchem package
+================
+
+Subpackages
+-----------
+
+.. toctree::
+   :maxdepth: 4
+
+   flowchem.client
+   flowchem.components
+   flowchem.devices
+   flowchem.server
+   flowchem.utils
+   flowchem.vendor
+
+Module contents
+---------------
+
+.. automodule:: flowchem
+   :members:
+   :show-inheritance:
+   :undoc-members:

--- a/docs/development/foundations/code_structure/modules.rst
+++ b/docs/development/foundations/code_structure/modules.rst
@@ -1,7 +1,0 @@
-Code Structure
-==============
-
-.. toctree::
-   :maxdepth: 4
-
-

--- a/docs/development/foundations/index.md
+++ b/docs/development/foundations/index.md
@@ -6,5 +6,5 @@
 
 ./valve_logic
 
-./code_structure/modules
+./code_structure/flowchem
 ```


### PR DESCRIPTION
It is necessary to update the file to access the code docstring in the documentation, at least in local.
The git-ignore should also have the _build folder. This folder is built in the documentation and is useful to inspect the documentation locally.