### PR TITLE
Files to show code structure in the read the docs (It is not generate automatically)

### DIFF
--- a/docs/development/foundations/code_structure/flowchem.client.rst
+++ b/docs/development/foundations/code_structure/flowchem.client.rst
@@ -1,0 +1,53 @@
+flowchem.client package
+=======================
+
+Submodules
+----------
+
+flowchem.client.async\_client module
+------------------------------------
+
+.. automodule:: flowchem.client.async_client
+   :members:
+   :show-inheritance:
+   :undoc-members:
+
+flowchem.client.client module
+-----------------------------
+
+.. automodule:: flowchem.client.client
+   :members:
+   :show-inheritance:
+   :undoc-members:
+
+flowchem.client.common module
+-----------------------------
+
+.. automodule:: flowchem.client.common
+   :members:
+   :show-inheritance:
+   :undoc-members:
+
+flowchem.client.component\_client module
+----------------------------------------
+
+.. automodule:: flowchem.client.component_client
+   :members:
+   :show-inheritance:
+   :undoc-members:
+
+flowchem.client.device\_client module
+-------------------------------------
+
+.. automodule:: flowchem.client.device_client
+   :members:
+   :show-inheritance:
+   :undoc-members:
+
+Module contents
+---------------
+
+.. automodule:: flowchem.client
+   :members:
+   :show-inheritance:
+   :undoc-members:

--- a/docs/development/foundations/code_structure/flowchem.components.analytics.rst
+++ b/docs/development/foundations/code_structure/flowchem.components.analytics.rst
@@ -1,0 +1,53 @@
+flowchem.components.analytics package
+=====================================
+
+Submodules
+----------
+
+flowchem.components.analytics.dad module
+----------------------------------------
+
+.. automodule:: flowchem.components.analytics.dad
+   :members:
+   :show-inheritance:
+   :undoc-members:
+
+flowchem.components.analytics.hplc module
+-----------------------------------------
+
+.. automodule:: flowchem.components.analytics.hplc
+   :members:
+   :show-inheritance:
+   :undoc-members:
+
+flowchem.components.analytics.ir module
+---------------------------------------
+
+.. automodule:: flowchem.components.analytics.ir
+   :members:
+   :show-inheritance:
+   :undoc-members:
+
+flowchem.components.analytics.ms module
+---------------------------------------
+
+.. automodule:: flowchem.components.analytics.ms
+   :members:
+   :show-inheritance:
+   :undoc-members:
+
+flowchem.components.analytics.nmr module
+----------------------------------------
+
+.. automodule:: flowchem.components.analytics.nmr
+   :members:
+   :show-inheritance:
+   :undoc-members:
+
+Module contents
+---------------
+
+.. automodule:: flowchem.components.analytics
+   :members:
+   :show-inheritance:
+   :undoc-members:

--- a/docs/development/foundations/code_structure/flowchem.components.meta_components.rst
+++ b/docs/development/foundations/code_structure/flowchem.components.meta_components.rst
@@ -1,0 +1,21 @@
+flowchem.components.meta\_components package
+============================================
+
+Submodules
+----------
+
+flowchem.components.meta\_components.gantry3D module
+----------------------------------------------------
+
+.. automodule:: flowchem.components.meta_components.gantry3D
+   :members:
+   :show-inheritance:
+   :undoc-members:
+
+Module contents
+---------------
+
+.. automodule:: flowchem.components.meta_components
+   :members:
+   :show-inheritance:
+   :undoc-members:

--- a/docs/development/foundations/code_structure/flowchem.components.pumps.rst
+++ b/docs/development/foundations/code_structure/flowchem.components.pumps.rst
@@ -1,0 +1,37 @@
+flowchem.components.pumps package
+=================================
+
+Submodules
+----------
+
+flowchem.components.pumps.hplc\_pump module
+-------------------------------------------
+
+.. automodule:: flowchem.components.pumps.hplc_pump
+   :members:
+   :show-inheritance:
+   :undoc-members:
+
+flowchem.components.pumps.pump module
+-------------------------------------
+
+.. automodule:: flowchem.components.pumps.pump
+   :members:
+   :show-inheritance:
+   :undoc-members:
+
+flowchem.components.pumps.syringe\_pump module
+----------------------------------------------
+
+.. automodule:: flowchem.components.pumps.syringe_pump
+   :members:
+   :show-inheritance:
+   :undoc-members:
+
+Module contents
+---------------
+
+.. automodule:: flowchem.components.pumps
+   :members:
+   :show-inheritance:
+   :undoc-members:

--- a/docs/development/foundations/code_structure/flowchem.components.rst
+++ b/docs/development/foundations/code_structure/flowchem.components.rst
@@ -1,0 +1,50 @@
+flowchem.components package
+===========================
+
+Subpackages
+-----------
+
+.. toctree::
+   :maxdepth: 4
+
+   flowchem.components.analytics
+   flowchem.components.meta_components
+   flowchem.components.pumps
+   flowchem.components.sensors
+   flowchem.components.technical
+   flowchem.components.valves
+
+Submodules
+----------
+
+flowchem.components.component\_info module
+------------------------------------------
+
+.. automodule:: flowchem.components.component_info
+   :members:
+   :show-inheritance:
+   :undoc-members:
+
+flowchem.components.device\_info module
+---------------------------------------
+
+.. automodule:: flowchem.components.device_info
+   :members:
+   :show-inheritance:
+   :undoc-members:
+
+flowchem.components.flowchem\_component module
+----------------------------------------------
+
+.. automodule:: flowchem.components.flowchem_component
+   :members:
+   :show-inheritance:
+   :undoc-members:
+
+Module contents
+---------------
+
+.. automodule:: flowchem.components
+   :members:
+   :show-inheritance:
+   :undoc-members:

--- a/docs/development/foundations/code_structure/flowchem.components.sensors.rst
+++ b/docs/development/foundations/code_structure/flowchem.components.sensors.rst
@@ -1,0 +1,37 @@
+flowchem.components.sensors package
+===================================
+
+Submodules
+----------
+
+flowchem.components.sensors.photo\_sensor module
+------------------------------------------------
+
+.. automodule:: flowchem.components.sensors.photo_sensor
+   :members:
+   :show-inheritance:
+   :undoc-members:
+
+flowchem.components.sensors.pressure\_sensor module
+---------------------------------------------------
+
+.. automodule:: flowchem.components.sensors.pressure_sensor
+   :members:
+   :show-inheritance:
+   :undoc-members:
+
+flowchem.components.sensors.sensor module
+-----------------------------------------
+
+.. automodule:: flowchem.components.sensors.sensor
+   :members:
+   :show-inheritance:
+   :undoc-members:
+
+Module contents
+---------------
+
+.. automodule:: flowchem.components.sensors
+   :members:
+   :show-inheritance:
+   :undoc-members:

--- a/docs/development/foundations/code_structure/flowchem.components.technical.rst
+++ b/docs/development/foundations/code_structure/flowchem.components.technical.rst
@@ -1,0 +1,53 @@
+flowchem.components.technical package
+=====================================
+
+Submodules
+----------
+
+flowchem.components.technical.length module
+-------------------------------------------
+
+.. automodule:: flowchem.components.technical.length
+   :members:
+   :show-inheritance:
+   :undoc-members:
+
+flowchem.components.technical.photo module
+------------------------------------------
+
+.. automodule:: flowchem.components.technical.photo
+   :members:
+   :show-inheritance:
+   :undoc-members:
+
+flowchem.components.technical.power module
+------------------------------------------
+
+.. automodule:: flowchem.components.technical.power
+   :members:
+   :show-inheritance:
+   :undoc-members:
+
+flowchem.components.technical.pressure module
+---------------------------------------------
+
+.. automodule:: flowchem.components.technical.pressure
+   :members:
+   :show-inheritance:
+   :undoc-members:
+
+flowchem.components.technical.temperature module
+------------------------------------------------
+
+.. automodule:: flowchem.components.technical.temperature
+   :members:
+   :show-inheritance:
+   :undoc-members:
+
+Module contents
+---------------
+
+.. automodule:: flowchem.components.technical
+   :members:
+   :show-inheritance:
+   :undoc-members:

--- a/docs/development/foundations/code_structure/flowchem.components.valves.rst
+++ b/docs/development/foundations/code_structure/flowchem.components.valves.rst
@@ -1,0 +1,37 @@
+flowchem.components.valves package
+==================================
+
+Submodules
+----------
+
+flowchem.components.valves.distribution\_valves module
+------------------------------------------------------
+
+.. automodule:: flowchem.components.valves.distribution_valves
+   :members:
+   :show-inheritance:
+   :undoc-members:
+
+flowchem.components.valves.injection\_valves module
+---------------------------------------------------
+
+.. automodule:: flowchem.components.valves.injection_valves
+   :members:
+   :show-inheritance:
+   :undoc-members:
+
+flowchem.components.valves.valve module
+---------------------------------------
+
+.. automodule:: flowchem.components.valves.valve
+   :members:
+   :show-inheritance:
+   :undoc-members:
+
+Module contents
+---------------
+
+.. automodule:: flowchem.components.valves
+   :members:
+   :show-inheritance:
+   :undoc-members:

--- a/docs/development/foundations/code_structure/flowchem.devices.bronkhorst.rst
+++ b/docs/development/foundations/code_structure/flowchem.devices.bronkhorst.rst
@@ -1,0 +1,29 @@
+flowchem.devices.bronkhorst package
+===================================
+
+Submodules
+----------
+
+flowchem.devices.bronkhorst.el\_flow module
+-------------------------------------------
+
+.. automodule:: flowchem.devices.bronkhorst.el_flow
+   :members:
+   :show-inheritance:
+   :undoc-members:
+
+flowchem.devices.bronkhorst.el\_flow\_component module
+------------------------------------------------------
+
+.. automodule:: flowchem.devices.bronkhorst.el_flow_component
+   :members:
+   :show-inheritance:
+   :undoc-members:
+
+Module contents
+---------------
+
+.. automodule:: flowchem.devices.bronkhorst
+   :members:
+   :show-inheritance:
+   :undoc-members:

--- a/docs/development/foundations/code_structure/flowchem.devices.custom.rst
+++ b/docs/development/foundations/code_structure/flowchem.devices.custom.rst
@@ -1,0 +1,29 @@
+flowchem.devices.custom package
+===============================
+
+Submodules
+----------
+
+flowchem.devices.custom.peltier\_cooler module
+----------------------------------------------
+
+.. automodule:: flowchem.devices.custom.peltier_cooler
+   :members:
+   :show-inheritance:
+   :undoc-members:
+
+flowchem.devices.custom.peltier\_cooler\_component module
+---------------------------------------------------------
+
+.. automodule:: flowchem.devices.custom.peltier_cooler_component
+   :members:
+   :show-inheritance:
+   :undoc-members:
+
+Module contents
+---------------
+
+.. automodule:: flowchem.devices.custom
+   :members:
+   :show-inheritance:
+   :undoc-members:

--- a/docs/development/foundations/code_structure/flowchem.devices.dataapex.rst
+++ b/docs/development/foundations/code_structure/flowchem.devices.dataapex.rst
@@ -1,0 +1,29 @@
+flowchem.devices.dataapex package
+=================================
+
+Submodules
+----------
+
+flowchem.devices.dataapex.clarity module
+----------------------------------------
+
+.. automodule:: flowchem.devices.dataapex.clarity
+   :members:
+   :show-inheritance:
+   :undoc-members:
+
+flowchem.devices.dataapex.clarity\_hplc\_control module
+-------------------------------------------------------
+
+.. automodule:: flowchem.devices.dataapex.clarity_hplc_control
+   :members:
+   :show-inheritance:
+   :undoc-members:
+
+Module contents
+---------------
+
+.. automodule:: flowchem.devices.dataapex
+   :members:
+   :show-inheritance:
+   :undoc-members:

--- a/docs/development/foundations/code_structure/flowchem.devices.hamilton.rst
+++ b/docs/development/foundations/code_structure/flowchem.devices.hamilton.rst
@@ -1,0 +1,45 @@
+flowchem.devices.hamilton package
+=================================
+
+Submodules
+----------
+
+flowchem.devices.hamilton.ml600 module
+--------------------------------------
+
+.. automodule:: flowchem.devices.hamilton.ml600
+   :members:
+   :show-inheritance:
+   :undoc-members:
+
+flowchem.devices.hamilton.ml600\_finder module
+----------------------------------------------
+
+.. automodule:: flowchem.devices.hamilton.ml600_finder
+   :members:
+   :show-inheritance:
+   :undoc-members:
+
+flowchem.devices.hamilton.ml600\_pump module
+--------------------------------------------
+
+.. automodule:: flowchem.devices.hamilton.ml600_pump
+   :members:
+   :show-inheritance:
+   :undoc-members:
+
+flowchem.devices.hamilton.ml600\_valve module
+---------------------------------------------
+
+.. automodule:: flowchem.devices.hamilton.ml600_valve
+   :members:
+   :show-inheritance:
+   :undoc-members:
+
+Module contents
+---------------
+
+.. automodule:: flowchem.devices.hamilton
+   :members:
+   :show-inheritance:
+   :undoc-members:

--- a/docs/development/foundations/code_structure/flowchem.devices.harvardapparatus.rst
+++ b/docs/development/foundations/code_structure/flowchem.devices.harvardapparatus.rst
@@ -1,0 +1,37 @@
+flowchem.devices.harvardapparatus package
+=========================================
+
+Submodules
+----------
+
+flowchem.devices.harvardapparatus.elite11 module
+------------------------------------------------
+
+.. automodule:: flowchem.devices.harvardapparatus.elite11
+   :members:
+   :show-inheritance:
+   :undoc-members:
+
+flowchem.devices.harvardapparatus.elite11\_finder module
+--------------------------------------------------------
+
+.. automodule:: flowchem.devices.harvardapparatus.elite11_finder
+   :members:
+   :show-inheritance:
+   :undoc-members:
+
+flowchem.devices.harvardapparatus.elite11\_pump module
+------------------------------------------------------
+
+.. automodule:: flowchem.devices.harvardapparatus.elite11_pump
+   :members:
+   :show-inheritance:
+   :undoc-members:
+
+Module contents
+---------------
+
+.. automodule:: flowchem.devices.harvardapparatus
+   :members:
+   :show-inheritance:
+   :undoc-members:

--- a/docs/development/foundations/code_structure/flowchem.devices.huber.rst
+++ b/docs/development/foundations/code_structure/flowchem.devices.huber.rst
@@ -1,0 +1,45 @@
+flowchem.devices.huber package
+==============================
+
+Submodules
+----------
+
+flowchem.devices.huber.chiller module
+-------------------------------------
+
+.. automodule:: flowchem.devices.huber.chiller
+   :members:
+   :show-inheritance:
+   :undoc-members:
+
+flowchem.devices.huber.huber\_finder module
+-------------------------------------------
+
+.. automodule:: flowchem.devices.huber.huber_finder
+   :members:
+   :show-inheritance:
+   :undoc-members:
+
+flowchem.devices.huber.huber\_temperature\_control module
+---------------------------------------------------------
+
+.. automodule:: flowchem.devices.huber.huber_temperature_control
+   :members:
+   :show-inheritance:
+   :undoc-members:
+
+flowchem.devices.huber.pb\_command module
+-----------------------------------------
+
+.. automodule:: flowchem.devices.huber.pb_command
+   :members:
+   :show-inheritance:
+   :undoc-members:
+
+Module contents
+---------------
+
+.. automodule:: flowchem.devices.huber
+   :members:
+   :show-inheritance:
+   :undoc-members:

--- a/docs/development/foundations/code_structure/flowchem.devices.knauer.rst
+++ b/docs/development/foundations/code_structure/flowchem.devices.knauer.rst
@@ -1,0 +1,93 @@
+flowchem.devices.knauer package
+===============================
+
+Submodules
+----------
+
+flowchem.devices.knauer.azura\_compact module
+---------------------------------------------
+
+.. automodule:: flowchem.devices.knauer.azura_compact
+   :members:
+   :show-inheritance:
+   :undoc-members:
+
+flowchem.devices.knauer.azura\_compact\_pump module
+---------------------------------------------------
+
+.. automodule:: flowchem.devices.knauer.azura_compact_pump
+   :members:
+   :show-inheritance:
+   :undoc-members:
+
+flowchem.devices.knauer.azura\_compact\_sensor module
+-----------------------------------------------------
+
+.. automodule:: flowchem.devices.knauer.azura_compact_sensor
+   :members:
+   :show-inheritance:
+   :undoc-members:
+
+flowchem.devices.knauer.dad module
+----------------------------------
+
+.. automodule:: flowchem.devices.knauer.dad
+   :members:
+   :show-inheritance:
+   :undoc-members:
+
+flowchem.devices.knauer.dad\_component module
+---------------------------------------------
+
+.. automodule:: flowchem.devices.knauer.dad_component
+   :members:
+   :show-inheritance:
+   :undoc-members:
+
+flowchem.devices.knauer.knauer\_autosampler module
+--------------------------------------------------
+
+.. automodule:: flowchem.devices.knauer.knauer_autosampler
+   :members:
+   :show-inheritance:
+   :undoc-members:
+
+flowchem.devices.knauer.knauer\_autosampler\_component module
+-------------------------------------------------------------
+
+.. automodule:: flowchem.devices.knauer.knauer_autosampler_component
+   :members:
+   :show-inheritance:
+   :undoc-members:
+
+flowchem.devices.knauer.knauer\_finder module
+---------------------------------------------
+
+.. automodule:: flowchem.devices.knauer.knauer_finder
+   :members:
+   :show-inheritance:
+   :undoc-members:
+
+flowchem.devices.knauer.knauer\_valve module
+--------------------------------------------
+
+.. automodule:: flowchem.devices.knauer.knauer_valve
+   :members:
+   :show-inheritance:
+   :undoc-members:
+
+flowchem.devices.knauer.knauer\_valve\_component module
+-------------------------------------------------------
+
+.. automodule:: flowchem.devices.knauer.knauer_valve_component
+   :members:
+   :show-inheritance:
+   :undoc-members:
+
+Module contents
+---------------
+
+.. automodule:: flowchem.devices.knauer
+   :members:
+   :show-inheritance:
+   :undoc-members:

--- a/docs/development/foundations/code_structure/flowchem.devices.magritek.rst
+++ b/docs/development/foundations/code_structure/flowchem.devices.magritek.rst
@@ -1,0 +1,37 @@
+flowchem.devices.magritek package
+=================================
+
+Submodules
+----------
+
+flowchem.devices.magritek.spinsolve module
+------------------------------------------
+
+.. automodule:: flowchem.devices.magritek.spinsolve
+   :members:
+   :show-inheritance:
+   :undoc-members:
+
+flowchem.devices.magritek.spinsolve\_control module
+---------------------------------------------------
+
+.. automodule:: flowchem.devices.magritek.spinsolve_control
+   :members:
+   :show-inheritance:
+   :undoc-members:
+
+flowchem.devices.magritek.utils module
+--------------------------------------
+
+.. automodule:: flowchem.devices.magritek.utils
+   :members:
+   :show-inheritance:
+   :undoc-members:
+
+Module contents
+---------------
+
+.. automodule:: flowchem.devices.magritek
+   :members:
+   :show-inheritance:
+   :undoc-members:

--- a/docs/development/foundations/code_structure/flowchem.devices.manson.rst
+++ b/docs/development/foundations/code_structure/flowchem.devices.manson.rst
@@ -1,0 +1,29 @@
+flowchem.devices.manson package
+===============================
+
+Submodules
+----------
+
+flowchem.devices.manson.manson\_component module
+------------------------------------------------
+
+.. automodule:: flowchem.devices.manson.manson_component
+   :members:
+   :show-inheritance:
+   :undoc-members:
+
+flowchem.devices.manson.manson\_power\_supply module
+----------------------------------------------------
+
+.. automodule:: flowchem.devices.manson.manson_power_supply
+   :members:
+   :show-inheritance:
+   :undoc-members:
+
+Module contents
+---------------
+
+.. automodule:: flowchem.devices.manson
+   :members:
+   :show-inheritance:
+   :undoc-members:

--- a/docs/development/foundations/code_structure/flowchem.devices.mettlertoledo.rst
+++ b/docs/development/foundations/code_structure/flowchem.devices.mettlertoledo.rst
@@ -1,0 +1,37 @@
+flowchem.devices.mettlertoledo package
+======================================
+
+Submodules
+----------
+
+flowchem.devices.mettlertoledo.icir module
+------------------------------------------
+
+.. automodule:: flowchem.devices.mettlertoledo.icir
+   :members:
+   :show-inheritance:
+   :undoc-members:
+
+flowchem.devices.mettlertoledo.icir\_control module
+---------------------------------------------------
+
+.. automodule:: flowchem.devices.mettlertoledo.icir_control
+   :members:
+   :show-inheritance:
+   :undoc-members:
+
+flowchem.devices.mettlertoledo.icir\_finder module
+--------------------------------------------------
+
+.. automodule:: flowchem.devices.mettlertoledo.icir_finder
+   :members:
+   :show-inheritance:
+   :undoc-members:
+
+Module contents
+---------------
+
+.. automodule:: flowchem.devices.mettlertoledo
+   :members:
+   :show-inheritance:
+   :undoc-members:

--- a/docs/development/foundations/code_structure/flowchem.devices.phidgets.rst
+++ b/docs/development/foundations/code_structure/flowchem.devices.phidgets.rst
@@ -1,0 +1,45 @@
+flowchem.devices.phidgets package
+=================================
+
+Submodules
+----------
+
+flowchem.devices.phidgets.bubble\_sensor module
+-----------------------------------------------
+
+.. automodule:: flowchem.devices.phidgets.bubble_sensor
+   :members:
+   :show-inheritance:
+   :undoc-members:
+
+flowchem.devices.phidgets.bubble\_sensor\_component module
+----------------------------------------------------------
+
+.. automodule:: flowchem.devices.phidgets.bubble_sensor_component
+   :members:
+   :show-inheritance:
+   :undoc-members:
+
+flowchem.devices.phidgets.pressure\_sensor module
+-------------------------------------------------
+
+.. automodule:: flowchem.devices.phidgets.pressure_sensor
+   :members:
+   :show-inheritance:
+   :undoc-members:
+
+flowchem.devices.phidgets.pressure\_sensor\_component module
+------------------------------------------------------------
+
+.. automodule:: flowchem.devices.phidgets.pressure_sensor_component
+   :members:
+   :show-inheritance:
+   :undoc-members:
+
+Module contents
+---------------
+
+.. automodule:: flowchem.devices.phidgets
+   :members:
+   :show-inheritance:
+   :undoc-members:

--- a/docs/development/foundations/code_structure/flowchem.devices.rst
+++ b/docs/development/foundations/code_structure/flowchem.devices.rst
@@ -1,0 +1,60 @@
+flowchem.devices package
+========================
+
+Subpackages
+-----------
+
+.. toctree::
+   :maxdepth: 4
+
+   flowchem.devices.bronkhorst
+   flowchem.devices.custom
+   flowchem.devices.dataapex
+   flowchem.devices.hamilton
+   flowchem.devices.harvardapparatus
+   flowchem.devices.huber
+   flowchem.devices.knauer
+   flowchem.devices.magritek
+   flowchem.devices.manson
+   flowchem.devices.mettlertoledo
+   flowchem.devices.phidgets
+   flowchem.devices.runze
+   flowchem.devices.vacuubrand
+   flowchem.devices.vapourtec
+   flowchem.devices.vicivalco
+   flowchem.devices.waters
+
+Submodules
+----------
+
+flowchem.devices.flowchem\_device module
+----------------------------------------
+
+.. automodule:: flowchem.devices.flowchem_device
+   :members:
+   :show-inheritance:
+   :undoc-members:
+
+flowchem.devices.known\_plugins module
+--------------------------------------
+
+.. automodule:: flowchem.devices.known_plugins
+   :members:
+   :show-inheritance:
+   :undoc-members:
+
+flowchem.devices.list\_known\_device\_type module
+-------------------------------------------------
+
+.. automodule:: flowchem.devices.list_known_device_type
+   :members:
+   :show-inheritance:
+   :undoc-members:
+
+Module contents
+---------------
+
+.. automodule:: flowchem.devices
+   :members:
+   :show-inheritance:
+   :undoc-members:

--- a/docs/development/foundations/code_structure/flowchem.devices.runze.rst
+++ b/docs/development/foundations/code_structure/flowchem.devices.runze.rst
@@ -1,0 +1,29 @@
+flowchem.devices.runze package
+==============================
+
+Submodules
+----------
+
+flowchem.devices.runze.runze\_valve module
+------------------------------------------
+
+.. automodule:: flowchem.devices.runze.runze_valve
+   :members:
+   :show-inheritance:
+   :undoc-members:
+
+flowchem.devices.runze.runze\_valve\_component module
+-----------------------------------------------------
+
+.. automodule:: flowchem.devices.runze.runze_valve_component
+   :members:
+   :show-inheritance:
+   :undoc-members:
+
+Module contents
+---------------
+
+.. automodule:: flowchem.devices.runze
+   :members:
+   :show-inheritance:
+   :undoc-members:

--- a/docs/development/foundations/code_structure/flowchem.devices.vacuubrand.rst
+++ b/docs/development/foundations/code_structure/flowchem.devices.vacuubrand.rst
@@ -1,0 +1,45 @@
+flowchem.devices.vacuubrand package
+===================================
+
+Submodules
+----------
+
+flowchem.devices.vacuubrand.constants module
+--------------------------------------------
+
+.. automodule:: flowchem.devices.vacuubrand.constants
+   :members:
+   :show-inheritance:
+   :undoc-members:
+
+flowchem.devices.vacuubrand.cvc3000 module
+------------------------------------------
+
+.. automodule:: flowchem.devices.vacuubrand.cvc3000
+   :members:
+   :show-inheritance:
+   :undoc-members:
+
+flowchem.devices.vacuubrand.cvc3000\_finder module
+--------------------------------------------------
+
+.. automodule:: flowchem.devices.vacuubrand.cvc3000_finder
+   :members:
+   :show-inheritance:
+   :undoc-members:
+
+flowchem.devices.vacuubrand.cvc3000\_pressure\_control module
+-------------------------------------------------------------
+
+.. automodule:: flowchem.devices.vacuubrand.cvc3000_pressure_control
+   :members:
+   :show-inheritance:
+   :undoc-members:
+
+Module contents
+---------------
+
+.. automodule:: flowchem.devices.vacuubrand
+   :members:
+   :show-inheritance:
+   :undoc-members:

--- a/docs/development/foundations/code_structure/flowchem.devices.vapourtec.rst
+++ b/docs/development/foundations/code_structure/flowchem.devices.vapourtec.rst
@@ -1,0 +1,53 @@
+flowchem.devices.vapourtec package
+==================================
+
+Submodules
+----------
+
+flowchem.devices.vapourtec.r2 module
+------------------------------------
+
+.. automodule:: flowchem.devices.vapourtec.r2
+   :members:
+   :show-inheritance:
+   :undoc-members:
+
+flowchem.devices.vapourtec.r2\_components\_control module
+---------------------------------------------------------
+
+.. automodule:: flowchem.devices.vapourtec.r2_components_control
+   :members:
+   :show-inheritance:
+   :undoc-members:
+
+flowchem.devices.vapourtec.r4\_heater module
+--------------------------------------------
+
+.. automodule:: flowchem.devices.vapourtec.r4_heater
+   :members:
+   :show-inheritance:
+   :undoc-members:
+
+flowchem.devices.vapourtec.r4\_heater\_channel\_control module
+--------------------------------------------------------------
+
+.. automodule:: flowchem.devices.vapourtec.r4_heater_channel_control
+   :members:
+   :show-inheritance:
+   :undoc-members:
+
+flowchem.devices.vapourtec.vapourtec\_finder module
+---------------------------------------------------
+
+.. automodule:: flowchem.devices.vapourtec.vapourtec_finder
+   :members:
+   :show-inheritance:
+   :undoc-members:
+
+Module contents
+---------------
+
+.. automodule:: flowchem.devices.vapourtec
+   :members:
+   :show-inheritance:
+   :undoc-members:

--- a/docs/development/foundations/code_structure/flowchem.devices.vicivalco.rst
+++ b/docs/development/foundations/code_structure/flowchem.devices.vicivalco.rst
@@ -1,0 +1,29 @@
+flowchem.devices.vicivalco package
+==================================
+
+Submodules
+----------
+
+flowchem.devices.vicivalco.vici\_valve module
+---------------------------------------------
+
+.. automodule:: flowchem.devices.vicivalco.vici_valve
+   :members:
+   :show-inheritance:
+   :undoc-members:
+
+flowchem.devices.vicivalco.vici\_valve\_component module
+--------------------------------------------------------
+
+.. automodule:: flowchem.devices.vicivalco.vici_valve_component
+   :members:
+   :show-inheritance:
+   :undoc-members:
+
+Module contents
+---------------
+
+.. automodule:: flowchem.devices.vicivalco
+   :members:
+   :show-inheritance:
+   :undoc-members:

--- a/docs/development/foundations/code_structure/flowchem.devices.waters.rst
+++ b/docs/development/foundations/code_structure/flowchem.devices.waters.rst
@@ -1,0 +1,29 @@
+flowchem.devices.waters package
+===============================
+
+Submodules
+----------
+
+flowchem.devices.waters.waters\_ms module
+-----------------------------------------
+
+.. automodule:: flowchem.devices.waters.waters_ms
+   :members:
+   :show-inheritance:
+   :undoc-members:
+
+flowchem.devices.waters.waters\_ms\_component module
+----------------------------------------------------
+
+.. automodule:: flowchem.devices.waters.waters_ms_component
+   :members:
+   :show-inheritance:
+   :undoc-members:
+
+Module contents
+---------------
+
+.. automodule:: flowchem.devices.waters
+   :members:
+   :show-inheritance:
+   :undoc-members:

--- a/docs/development/foundations/code_structure/flowchem.server.rst
+++ b/docs/development/foundations/code_structure/flowchem.server.rst
@@ -1,0 +1,45 @@
+flowchem.server package
+=======================
+
+Submodules
+----------
+
+flowchem.server.configuration\_parser module
+--------------------------------------------
+
+.. automodule:: flowchem.server.configuration_parser
+   :members:
+   :show-inheritance:
+   :undoc-members:
+
+flowchem.server.core module
+---------------------------
+
+.. automodule:: flowchem.server.core
+   :members:
+   :show-inheritance:
+   :undoc-members:
+
+flowchem.server.fastapi\_server module
+--------------------------------------
+
+.. automodule:: flowchem.server.fastapi_server
+   :members:
+   :show-inheritance:
+   :undoc-members:
+
+flowchem.server.zeroconf\_server module
+---------------------------------------
+
+.. automodule:: flowchem.server.zeroconf_server
+   :members:
+   :show-inheritance:
+   :undoc-members:
+
+Module contents
+---------------
+
+.. automodule:: flowchem.server
+   :members:
+   :show-inheritance:
+   :undoc-members:

--- a/docs/development/foundations/code_structure/flowchem.utils.rst
+++ b/docs/development/foundations/code_structure/flowchem.utils.rst
@@ -1,0 +1,37 @@
+flowchem.utils package
+======================
+
+Submodules
+----------
+
+flowchem.utils.device\_finder module
+------------------------------------
+
+.. automodule:: flowchem.utils.device_finder
+   :members:
+   :show-inheritance:
+   :undoc-members:
+
+flowchem.utils.exceptions module
+--------------------------------
+
+.. automodule:: flowchem.utils.exceptions
+   :members:
+   :show-inheritance:
+   :undoc-members:
+
+flowchem.utils.people module
+----------------------------
+
+.. automodule:: flowchem.utils.people
+   :members:
+   :show-inheritance:
+   :undoc-members:
+
+Module contents
+---------------
+
+.. automodule:: flowchem.utils
+   :members:
+   :show-inheritance:
+   :undoc-members:

--- a/docs/development/foundations/code_structure/flowchem.vendor.rst
+++ b/docs/development/foundations/code_structure/flowchem.vendor.rst
@@ -1,0 +1,29 @@
+flowchem.vendor package
+=======================
+
+Submodules
+----------
+
+flowchem.vendor.getmac module
+-----------------------------
+
+.. automodule:: flowchem.vendor.getmac
+   :members:
+   :show-inheritance:
+   :undoc-members:
+
+flowchem.vendor.repeat\_every module
+------------------------------------
+
+.. automodule:: flowchem.vendor.repeat_every
+   :members:
+   :show-inheritance:
+   :undoc-members:
+
+Module contents
+---------------
+
+.. automodule:: flowchem.vendor
+   :members:
+   :show-inheritance:
+   :undoc-members:

--- a/docs/development/foundations/code_structure/modules.rst
+++ b/docs/development/foundations/code_structure/modules.rst
@@ -1,0 +1,7 @@
+src
+===
+
+.. toctree::
+   :maxdepth: 4
+
+   flowchem


### PR DESCRIPTION
Files showing the code structure in the 'Read the Docs' section are not generated automatically.

I believe it cannot be generated automatically because it would add files to the repository, which is not allowed since the package is protected.

Files showing the code structure in the 'Read the Docs' section are not generated automatically.

I believe it cannot be generated automatically because it would add files to the repository, which is not allowed since the package is protected.

This means that, every time the docstring or code structure is changed, the above command should be run.

sphinx-apidoc -o docs/development/foundations/code_structure src